### PR TITLE
fix: v1.0.5.0 — TextInput crash fix, beacon height, help dialog, FarmTablet key guard

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -12,6 +12,11 @@ local modName      = g_currentModName
 local modItem      = g_modManager:getModByName(modName)
 local modVersion   = modItem and modItem.version or "0.0.0"
 
+-- Capture keyEvent chain BEFORE later-loading mods (e.g. FS25_FarmTablet)
+-- append their handlers. CTC loads alphabetically before 'F' mods, so this
+-- snapshot is clean of FarmTablet's T-key hook.
+local preModKeyEvent = Mission00.keyEvent
+
 print("[CTC] Starting FS25_CustomTriggerCreator v" .. modVersion .. " ...")
 
 if not modDirectory then
@@ -190,6 +195,19 @@ local function onLoadFinished(mission, node)
     DialogLoader.ensureLoaded("CTConfirmDialog")
     DialogLoader.ensureLoaded("CTSettingsDialog")
     DialogLoader.ensureLoaded("CTHelpDialog")
+
+    -- Install keyEvent guard AFTER all mods have hooked Mission00.keyEvent.
+    -- When any GUI dialog is active, route through the pre-mod keyEvent snapshot
+    -- (which handles g_gui internally) instead of the full chain that includes
+    -- third-party mod hooks like FS25_FarmTablet's hardcoded 'T' key handler.
+    local fullKeyEvent = Mission00.keyEvent
+    Mission00.keyEvent = function(mission, ...)
+        if g_gui ~= nil and g_gui.currentGui ~= nil then
+            return preModKeyEvent(mission, ...)
+        end
+        return fullKeyEvent(mission, ...)
+    end
+    Logger.info("keyEvent guard installed (blocks mod key handlers while dialogs are open)")
 
     ctcSystem:onMissionLoaded()
 end

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="105">
     <author>TisonK</author>
-    <version>1.0.4.0</version>
+    <version>1.0.5.0</version>
     <modName>FS25_CustomTriggerCreator</modName>
     <title>
         <en>Custom Trigger Creator</en>


### PR DESCRIPTION
## Summary

- **TextInput draw crash fixed**: `maxInputTextWidth` was nil, causing `TextInputElement.draw()` to throw every frame — text invisible, mouse glitchy. Added `maxInputTextWidth="472px"` to both input profiles.
- **Beacon height corrected**: World-space `[T] Name` label now projects from `wy+2.5` instead of `wy+0.2`, rendering clearly above the 3D marker icon.
- **Proper help dialog**: `CTHelpDialog` (two-column categorized layout) replaces the `CTConfirmDialog` hack.
- **FarmTablet T-key guard**: Captures `Mission00.keyEvent` before FS25_FarmTablet loads, installs a guard in `onLoadFinished` that routes through the pre-mod snapshot while any dialog is active — blocking third-party key handlers from firing during text input.

## Closes

- #15

## Test plan

- [ ] Open builder wizard — type in all fields — text is visible, no log errors
- [ ] Typing 'T' in a field does NOT open FarmTablet
- [ ] FarmTablet still works normally when no CTC dialog is open
- [ ] Help button opens proper two-column help dialog
- [ ] Beacon `[T] Name` renders above the 3D icon, not inside it