### PR TITLE
fix: MP dedicated server — route economy operations through server event

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -48,6 +48,11 @@ source(modDirectory .. "src/core/CTWorldManager.lua")
 source(modDirectory .. "src/core/CTMarkerManager.lua")
 
 -- =========================================================
+-- Network events
+-- =========================================================
+source(modDirectory .. "src/CTCNetworkEvent.lua")
+
+-- =========================================================
 -- Triggers
 -- =========================================================
 source(modDirectory .. "src/triggers/BaseTrigger.lua")

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="105">
     <author>TisonK</author>
-    <version>1.0.5.1</version>
+    <version>1.0.6.0</version>
     <modName>FS25_CustomTriggerCreator</modName>
     <title>
         <en>Custom Trigger Creator</en>
@@ -11,7 +11,7 @@
         <en>Create, configure, and manage custom interaction triggers in-game — no XML or Lua required. Supports basic and advanced multi-step chained trigger flows.</en>
         <de>Erstelle, konfiguriere und verwalte benutzerdefinierte Interaktionsauslöser im Spiel — kein XML oder Lua erforderlich. Unterstützt einfache und erweiterte mehrstufige Auslöserketten.</de>
     </description>
-    <iconFilename>icon.png</iconFilename>
+    <iconFilename>icon.dds</iconFilename>
 
     <l10n filenamePrefix="translations/translation" defaultLanguage="en" />
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="105">
     <author>TisonK</author>
-    <version>1.0.6.0</version>
+    <version>1.0.7.0</version>
     <modName>FS25_CustomTriggerCreator</modName>
     <title>
         <en>Custom Trigger Creator</en>

--- a/src/CTCNetworkEvent.lua
+++ b/src/CTCNetworkEvent.lua
@@ -1,0 +1,41 @@
+-- =========================================================
+-- CTCNetworkEvent.lua -- FS25_CustomTriggerCreator
+-- Routes economy addMoney calls from client to server.
+-- Only used when the local machine is a client (not the server).
+-- =========================================================
+
+CTCNetworkEvent = {}
+CTCNetworkEvent_mt = Class(CTCNetworkEvent, Event)
+InitEventClass(CTCNetworkEvent, "CTCNetworkEvent")
+
+function CTCNetworkEvent.emptyNew()
+    local self = Event.new(CTCNetworkEvent_mt)
+    return self
+end
+
+---@param farmId  number  Farm to receive/pay the money
+---@param amount  number  Positive = farm receives, negative = farm pays
+function CTCNetworkEvent.new(farmId, amount)
+    local self = CTCNetworkEvent.emptyNew()
+    self.farmId = farmId
+    self.amount = amount
+    return self
+end
+
+function CTCNetworkEvent:writeStream(streamId, connection)
+    streamWriteInt32(streamId, self.farmId or 0)
+    streamWriteInt32(streamId, self.amount  or 0)
+end
+
+function CTCNetworkEvent:readStream(streamId, connection)
+    self.farmId = streamReadInt32(streamId)
+    self.amount  = streamReadInt32(streamId)
+    self:run(connection)
+end
+
+-- Server-side: apply the money operation
+function CTCNetworkEvent:run(connection)
+    if not g_currentMission:getIsServer() then return end
+    if not self.farmId or self.farmId <= 0 then return end
+    g_currentMission:addMoney(self.amount, self.farmId, MoneyType.OTHER, true)
+end

--- a/src/triggers/EconomyTrigger.lua
+++ b/src/triggers/EconomyTrigger.lua
@@ -47,7 +47,7 @@ function EconomyTrigger:_applyMoney(delta)
     local farmId = self:_getPlayerFarmId()
     if not farmId then return BaseTrigger.RESULT.ERROR end
 
-    -- Check balance for fees
+    -- Check balance for fees (local check — server will be authoritative)
     if delta < 0 then
         local farm = g_farmManager and g_farmManager:getFarmById(farmId)
         local balance = farm and farm.money or 0
@@ -57,7 +57,11 @@ function EconomyTrigger:_applyMoney(delta)
         end
     end
 
-    g_currentMission:addMoney(delta, farmId, MoneyType.OTHER, true)
+    if g_currentMission:getIsServer() then
+        g_currentMission:addMoney(delta, farmId, MoneyType.OTHER, true)
+    else
+        g_client:getServerConnection():sendEvent(CTCNetworkEvent.new(farmId, delta))
+    end
 
     local label = delta >= 0 and ("+" .. delta .. "$") or (delta .. "$")
     self:_notify(label, delta >= 0 and "SUCCESS" or "INFO")


### PR DESCRIPTION
## Summary

- `EconomyTrigger._applyMoney` previously called `g_currentMission:addMoney()` on whichever machine activated the trigger — in MP only that machine's balance changed
- Added `src/CTCNetworkEvent.lua`: a minimal FS25 `Event` subclass that streams `farmId` and `amount` (int32) from client to server, then calls `addMoney` on the server side
- `EconomyTrigger._applyMoney` now routes: server executes directly, client sends `CTCNetworkEvent` to the server
- The `_barter` method calls `_applyMoney` for its cost deduction so it is covered by the same fix
- Network event sourced in `main.lua` before trigger classes load
- Version bumped to 1.0.7.0

## Test plan

- [ ] In MP (listen server + 1 client), activate a PAY_FEE trigger from the client — verify both machines show the balance change
- [ ] Activate an EARN trigger from the client — verify money is added on the server and synced to the client
- [ ] Activate a BARTER trigger with a cost from the client — verify cost deducted server-side
- [ ] Activate any economy trigger from the host — verify direct path still works (no event sent)
- [ ] Load on a dedicated server — check log.txt for no stream errors